### PR TITLE
feat: highlight leader on last completed round only

### DIFF
--- a/app/controllers/games_controller.rb
+++ b/app/controllers/games_controller.rb
@@ -12,6 +12,8 @@ class GamesController < ApplicationController
     @remaining_players = Player.all - @game.players
     @rounds = @game.rounds
     @winner = @game.winner
+    @last_completed_round = @game.last_completed_round
+    @leaders = @last_completed_round&.leaders || []
   end
 
   def new

--- a/app/models/game.rb
+++ b/app/models/game.rb
@@ -71,6 +71,13 @@ class Game < ApplicationRecord
     rounds.find_by(phase: 'down', length: 1)
   end
 
+  def last_completed_round
+    total_players = players.count
+    rounds.order(:position).to_a.reverse.find do |r|
+      r.predictions.count { |p| p.actual_tricks.present? } == total_players
+    end
+  end
+
   def check_if_finished!
     last = last_round
     return unless last

--- a/app/models/round.rb
+++ b/app/models/round.rb
@@ -42,4 +42,11 @@ class Round < ApplicationRecord
   def leader_score
     scores.maximum(:cumulative_value)
   end
+
+  def leaders
+    top = scores.maximum(:cumulative_value)
+    return [] unless top
+
+    scores.where(cumulative_value: top).map(&:player)
+  end
 end

--- a/app/views/games/show.html.erb
+++ b/app/views/games/show.html.erb
@@ -22,7 +22,7 @@
       </thead>
       <tbody>
         <% @game.rounds.order(:position).each do |round| %>
-          <% cache ["round_row", round.id, round.predictions.maximum(:updated_at)] do %>
+          <% cache ["round_row", round.id, round.predictions.maximum(:updated_at), @last_completed_round&.id] do %>
             <tr class="bg-white border-b dark:bg-gray-800 dark:border-gray-700 border-gray-200 hover:bg-gray-50 dark:hover:bg-gray-600">
               <!-- Round number -->
               <th scope="row" class="px-6 py-4 font-medium text-gray-900 whitespace-nowrap dark:text-white">
@@ -34,7 +34,7 @@
                 <% prediction = round.predictions.find_by(player: player) %>
                 <% winner_classes = "px-6 py-4" %>
 
-                <% if player == @winner %>
+                <% if round == @last_completed_round && @leaders.include?(player) %>
                   <% winner_classes += " border-4 border-double border-yellow-400 dark:border-yellow-500 font-bold" %>
                 <% end %>
 


### PR DESCRIPTION
Replace the full-column winner highlight (all rounds, yellow) with a targeted border on the leader's cell in the last completed round only. Handles ties by highlighting all co-leaders.